### PR TITLE
References official docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker py3dtiles
 
-**Note:** Py3dtiles has now an [official docker image](https://hub.docker.com/r/py3dtiles/py3dtiles).
+**Note:** Py3dtiles now has an [official docker image](https://hub.docker.com/r/py3dtiles/py3dtiles).
 
 [py3dtiles](https://gitlab.com/Oslandia/py3dtiles) installed docker image.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # docker py3dtiles
 
+**Note:** Py3dtiles has now an [official docker image](https://hub.docker.com/r/py3dtiles/py3dtiles).
+
 [py3dtiles](https://gitlab.com/Oslandia/py3dtiles) installed docker image.
 
 Also you can use [pdal](https://pdal.io/).


### PR DESCRIPTION
Fixes #1  .

Changes proposed in this pull request:
- Adds note about official docker image.

@ha4db/maintainer
